### PR TITLE
Fix initiateTransaction method

### DIFF
--- a/android/app/src/main/java/com/lpaapp/ECDSAManager/ECTransactionModule.java
+++ b/android/app/src/main/java/com/lpaapp/ECDSAManager/ECTransactionModule.java
@@ -65,7 +65,8 @@ public class ECTransactionModule extends ReactContextBaseJavaModule {
                     calldata
             );
 
-            byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, privateKey);
+            Credentials txnCredentials = Credentials.create(privateKey);      
+            byte[] signedMessage = TransactionEncoder.signMessage(rawTransaction, txnCredentials);
             String hexValue = Numeric.toHexString(signedMessage);
 
             //signed transaction is sent using ethSendRawTransaction

--- a/android/src/App.tsx
+++ b/android/src/App.tsx
@@ -155,21 +155,31 @@ export default function App() {
 
   const generateKeyStore = async () => {
     try {
-      const {ecPublicKey, encrypted_key, msg} =
-        await NativeModules.KeyStore.generateAndStoreECKeyPair(
-            appAlias,
-            'Test123',
-            RNFS.DownloadDirectoryPath,
-            );
-      console.log(ecPublicKey);
-      console.log(msg);
-      console.log(encrypted_key);
+      const publicKey = retrieveData(EC_PUBLIC_KEY);
+      console.log('EC Public Key: ', publicKey);
 
-      storeData(EC_PUBLIC_KEY, ecPublicKey);
-      storeData(ENCRYPTED_EC_PRIVATE_KEY, encrypted_key);
-      console.log('Keys Securely Stored');
+      const privateKey = retrieveData(ENCRYPTED_EC_PRIVATE_KEY);
+      console.log('Encrypted EC Private Key: ', privateKey);
 
-      setEncryptedKey(encrypted_key);
+      if (publicKey == null || privateKey == null){
+        const {ecPublicKey, encrypted_key, msg} =
+          await NativeModules.KeyStore.generateAndStoreECKeyPair(
+              appAlias,
+              'Test123',
+              RNFS.DownloadDirectoryPath,
+              );
+        console.log('EC Public Key: ', ecPublicKey);
+        console.log(msg);
+        console.log('Encrypted Private Key: ', encrypted_key);
+
+        storeData(EC_PUBLIC_KEY, ecPublicKey);
+        storeData(ENCRYPTED_EC_PRIVATE_KEY, encrypted_key);
+        console.log('Keys Securely Stored');
+
+        setEncryptedKey(encrypted_key);
+      }
+
+      setEncryptedKey(privateKey);
       toggleKeyModalVisibility();
     } catch (error) {
       console.log('Error: ', error);


### PR DESCRIPTION
- Fixed error associated with initiateTransaction method in ECTransactionManager.
- Parameter passed to signTransaction had to be of the type web3j.Credentials
- Changed behavior for generateECKey button to retrieve stored keys if already present in app